### PR TITLE
two fixes

### DIFF
--- a/flashtext2/__init__.py
+++ b/flashtext2/__init__.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 from .keyword_processor import KeywordProcessor
 from .trie_dict import TrieDict
-from .exceptions import FlashTextException, WordNotFoundError
+from .exceptions import FlashTextException, WordNotFoundError, MatchingConflictException

--- a/flashtext2/exceptions.py
+++ b/flashtext2/exceptions.py
@@ -13,3 +13,16 @@ class WordNotFoundError(FlashTextException):
     Raised when given word isn't present in the tree data structure
     """
     pass
+
+
+class MatchingConflictException(FlashTextException):
+    """
+
+    """
+    def __init__(self, key: str, val1: str, val2: str):
+        self.key = key
+        self.val1 = val1
+        self.val2 = val2
+
+    def __str__(self):
+        return f'Duplicate values: {self.key} matches both {self.val1} and {self.val2}'

--- a/flashtext2/keyword_processor.py
+++ b/flashtext2/keyword_processor.py
@@ -6,7 +6,7 @@ from .trie_dict import TrieDict
 
 
 class KeywordProcessor(TrieDict):
-    def __init__(self, case_sensitive: bool = False) -> None:
+    def __init__(self, case_sensitive: bool = False, include_keys = True) -> None:
         """
         Initialize the Keyword Processor
 
@@ -14,7 +14,7 @@ class KeywordProcessor(TrieDict):
 
         :param case_sensitive: bool, default False
         """
-        super().__init__(case_sensitive)
+        super().__init__(case_sensitive, include_keys)
 
     @overload
     def extract_keywords(self, sentence: str, span_info: bool = False) -> list[str]:

--- a/local_run.py
+++ b/local_run.py
@@ -1,0 +1,34 @@
+from flashtext2 import KeywordProcessor, MatchingConflictException
+
+try:
+    kp = KeywordProcessor()
+    kp.add_keywords_from_dict({
+        "New York": ["NYC", "NY", "Big Apple"],
+        "Los Angeles": ["LA"]
+    })
+
+    print(kp.extract_keywords("I visited New York"))
+except MatchingConflictException as err:
+    print(str(err))
+
+try:
+    kp = KeywordProcessor()
+    kp.add_keywords_from_dict({
+        "New York": ["NYC", "NY", "Big Apple"],
+        "Los Angeles": ["LA", "Big Apple"]
+    })
+
+    print(kp.extract_keywords("I visited New York"))
+except MatchingConflictException as err:
+    print(str(err))
+
+try:
+    kp = KeywordProcessor()
+    kp.add_keywords_from_dict({
+        "New York": ["NYC", "NY", "Big Apple"],
+        "Los Angeles": ["LA"]
+    })
+
+    print(kp.extract_keywords("I visited NY and LA"))
+except MatchingConflictException as err:
+    print(str(err))


### PR DESCRIPTION
Please, look at local_run.py to see the fixes in action:
1. I am ensuring that the clean_word can be always found, even if it is not explicitly added to the word-clean_word dict;
2. I am raising an exception if the same words is mapped to two different clean words

Also, I would recommend to replace unittest by pytest. I can implement that, if it is ok with you